### PR TITLE
Update examples to use `latest` packages and `ckeditor5` CDN.

### DIFF
--- a/Vite-React/package.json
+++ b/Vite-React/package.json
@@ -10,8 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ckeditor/ckeditor5-react": "^6.2.0",
-    "ckeditor5": "nightly",
+    "@ckeditor/ckeditor5-react": "^8.0.0",
+    "ckeditor5": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/browser/public/index_core.html
+++ b/browser/public/index_core.html
@@ -9,7 +9,7 @@
 	<link rel="icon" href="data:;base64,iVBORw0KGgo=">
 
 	<!-- Editor styles -->
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ckeditor5@nightly/dist/browser/ckeditor5.css">
+	<link rel="stylesheet" href="https://cdn.ckeditor.com/ckeditor5/42.0.0/ckeditor5.css">
 </head>
 <body>
 
@@ -26,11 +26,12 @@
 	<script type="importmap">
 		{
 			"imports": {
-				"ckeditor5": "https://cdn.jsdelivr.net/npm/ckeditor5@nightly/dist/browser/ckeditor5.js",
-				"ckeditor5/": "https://cdn.jsdelivr.net/npm/ckeditor5@nightly/dist/"
+				"ckeditor5": "https://cdn.ckeditor.com/ckeditor5/42.0.0/ckeditor5.js",
+				"ckeditor5/": "https://cdn.ckeditor.com/ckeditor5/42.0.0/"
 			}
 		}
 	</script>
+
 
 	<!-- Editor initialization code -->
 	<script type="module">

--- a/browser/public/index_with_premium.html
+++ b/browser/public/index_with_premium.html
@@ -9,8 +9,8 @@
 	<link rel="icon" href="data:;base64,iVBORw0KGgo=">
 
 	<!-- Editor styles -->
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ckeditor5@nightly/dist/browser/ckeditor5.css">
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ckeditor5-premium-features@nightly/dist/browser/ckeditor5-premium-features.css">
+	<link rel="stylesheet" href="https://cdn.ckeditor.com/ckeditor5/42.0.0/ckeditor5.css">
+	<link rel="stylesheet" href="https://cdn.ckeditor.com/ckeditor5-premium-features/42.0.0/ckeditor5-premium-features.css">
 </head>
 <body>
 
@@ -23,14 +23,14 @@
 		ipsum eleifend congue. Ut placerat condimentum nunc, in aliquet libero elementum a.
 	</div>
 
-	<!-- Importmap including ckeditor5 -->
+	<!-- Importmap including ckeditor5 and ckeditor5-premium-features -->
 	<script type="importmap">
 		{
 			"imports": {
-				"ckeditor5": "https://cdn.jsdelivr.net/npm/ckeditor5@nightly/dist/browser/ckeditor5.js",
-				"ckeditor5/": "https://cdn.jsdelivr.net/npm/ckeditor5@nightly/dist/",
-				"ckeditor5-premium-features": "https://cdn.jsdelivr.net/npm/ckeditor5-premium-features@nightly/dist/browser/ckeditor5-premium-features.js",
-				"ckeditor5-premium-features/": "https://cdn.jsdelivr.net/npm/ckeditor5-premium-features@nightly/dist/"
+				"ckeditor5": "https://cdn.ckeditor.com/ckeditor5/42.0.0/ckeditor5.js",
+				"ckeditor5/": "https://cdn.ckeditor.com/ckeditor5/42.0.0/",
+				"ckeditor5-premium-features": "https://cdn.ckeditor.com/ckeditor5-premium-features/42.0.0/ckeditor5-premium-features.js",
+				"ckeditor5-premium-features/": "https://cdn.ckeditor.com/ckeditor5-premium-features/42.0.0/"
 			}
 		}
 	</script>

--- a/browser/public/index_with_premium_umd.html
+++ b/browser/public/index_with_premium_umd.html
@@ -9,8 +9,8 @@
 	<link rel="icon" href="data:;base64,iVBORw0KGgo=">
 
 	<!-- Editor styles -->
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ckeditor5@nightly/dist/browser/ckeditor5.css">
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ckeditor5-premium-features@nightly/dist/browser/ckeditor5-premium-features.css">
+	<link rel="stylesheet" href="https://cdn.ckeditor.com/ckeditor5/42.0.0/ckeditor5.css">
+	<link rel="stylesheet" href="https://cdn.ckeditor.com/ckeditor5-premium-features/42.0.0/ckeditor5-premium-features.css">
 </head>
 <body>
 
@@ -24,12 +24,12 @@
 	</div>
 
 	<!-- Editor code -->
-	<script src="https://cdn.jsdelivr.net/npm/ckeditor5@nightly/dist/browser/ckeditor5.umd.js"></script>
-	<script src="https://cdn.jsdelivr.net/npm/ckeditor5-premium-features@nightly/dist/browser/ckeditor5-premium-features.umd.js"></script>
+	<script src="https://cdn.ckeditor.com/ckeditor5/42.0.0/ckeditor5.umd.js"></script>
+	<script src="https://cdn.ckeditor.com/ckeditor5-premium-features/42.0.0/ckeditor5-premium-features.umd.js"></script>
 
 	<!-- Editor translations -->
-	<script src="https://cdn.jsdelivr.net/npm/ckeditor5@nightly/dist/translations/pl.umd.js"></script>
-	<script src="https://cdn.jsdelivr.net/npm/ckeditor5-premium-features@nightly/dist/translations/pl.umd.js"></script>
+	<script src="https://cdn.ckeditor.com/ckeditor5/42.0.0/translations/pl.umd.js"></script>
+	<script src="https://cdn.ckeditor.com/ckeditor5-premium-features/42.0.0/translations/pl.umd.js"></script>
 
 	<!-- Editor initialization code -->
 	<script>

--- a/vite/package.json
+++ b/vite/package.json
@@ -12,7 +12,7 @@
     "vite": "^5.0.0"
   },
   "dependencies": {
-    "ckeditor5": "nightly",
-    "ckeditor5-premium-features": "nightly"
+    "ckeditor5": "latest",
+    "ckeditor5-premium-features": "latest"
   }
 }

--- a/webpack/package.json
+++ b/webpack/package.json
@@ -16,7 +16,7 @@
     "webpack-dev-server": "^4.15.1"
   },
   "dependencies": {
-    "ckeditor5": "nightly",
-    "ckeditor5-premium-features": "nightly"
+    "ckeditor5": "latest",
+    "ckeditor5-premium-features": "latest"
   }
 }


### PR DESCRIPTION
Update examples to use `latest` packages and `ckeditor5` CDN.